### PR TITLE
Added code to follow redirects

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,7 +66,8 @@ curl_setopt($ch, CURLOPT_COOKIEFILE, "cookie_jar.txt");
 curl_setopt($ch, CURLOPT_URL,"http://socialclub.rockstargames.com/games/gtav/career/overviewAjax?character=Freemode&nickname=".$target."&slot=Freemode&gamerHandle=&gamerTag=&_=".time()."000");
 curl_setopt($ch, CURLOPT_HTTPHEADER, array(
   'Accept-Encoding: gzip, deflate',
-  )
+  ),
+curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE)
 );
 
 $buf3 = curl_exec ($ch);


### PR DESCRIPTION
*Based on Issue #3.

This is my first pull request at Github on another project,
so please bare with me.

I added a CURL option to follow redirects.
Although, this is temporary, as they probably no longer want you to access
"http://socialclub.rockstargames.com/games/gtav/career/", as 
whenever you access this URL when logged in,
it redirects to a URL specific to your device(I'm on PC, so "http://socialclub.rockstargames.com/games/gtav/pc/career/").
